### PR TITLE
タブ切替時のロジックを修正

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,12 +3,22 @@ import Layout from "./components/Layout";
 import Login from "./pages/Login";
 import ItemPage from "./pages/Item";
 import ChatPage from "./pages/Chat";
+import Chats from "./pages/Chats";
+import SoldItem from "./pages/SoldItem";
+import Home from "./pages/Home";
 import MyPage from "./pages/MyPage";
 
 function App() {
   return (
     <Routes>
-      <Route path="/" element={<Layout />} />
+      {/* ヘッダーとフッターを常に表示するページ */}
+      <Route path="/" element={<Layout />}>
+        <Route index element={<Home />} />
+        <Route path="chats" element={<Chats />} />
+        <Route path="sold-items" element={<SoldItem />} />
+      </Route>
+
+      {/* 独立したページ */}
       <Route path="/login" element={<Login />} />
       <Route path="/item/:item_id" element={<ItemPage />} />
       <Route path="/chat/:item_id" element={<ChatPage />} />

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,17 +1,18 @@
 import { Home, MessageCircle, Plus } from 'lucide-react';
 
-type FooterTabType = 'home' | 'soldItems' | 'chats';
+type FooterTabType = 'home' | 'sold-items' | 'chats';
+type tabPathType = '/' | '/sold-items' | '/chats';
 
 interface FooterProps {
   activeTab: FooterTabType;
-  onTabChange: (tab: FooterTabType) => void;
+  onTabChange: (tab: tabPathType) => void;
 }
 
 export default function Footer({ activeTab, onTabChange }: FooterProps) {
   const tabs = [
-    { id: 'home' as FooterTabType, label: 'ホーム', icon: Home },
-    { id: 'soldItems' as FooterTabType, label: '出品', icon: Plus },
-    { id: 'chats' as FooterTabType, label: 'チャット', icon: MessageCircle },
+    { id: 'home' as FooterTabType, label: 'ホーム', icon: Home, path: '/' },
+    { id: 'soldItems' as FooterTabType, label: '出品', icon: Plus, path: '/sold-items' },
+    { id: 'chats' as FooterTabType, label: 'チャット', icon: MessageCircle, path: '/chats' },
   ];
 
   return (
@@ -21,7 +22,7 @@ export default function Footer({ activeTab, onTabChange }: FooterProps) {
           {tabs.map((tab) => (
             <button
               key={tab.id}
-              onClick={() => onTabChange(tab.id)}
+              onClick={() => onTabChange(tab.path as tabPathType)}
               className={`flex flex-col items-center font-medium text-sm transition-colors ${
                 activeTab === tab.id
                   ? 'text-blue-500'

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,24 +1,29 @@
-import { useState } from 'react';
+import { useLocation, useNavigate, Outlet } from 'react-router-dom';
 import Header from './Header/index';
 import Footer from './Footer';
-import Home from '../pages/Home';
-import Chats from '../pages/Chats';
-import SoldItem from '../pages/SoldItem';
-
-type FooterTabType = 'home' | 'soldItems' | 'chats';
 
 export default function Layout() {
-  const [activeFooterTab, setActiveFooterTab] = useState<FooterTabType>('home');
 
-  const renderContent = () => {
-    switch (activeFooterTab) {
-      case 'home':
-        return <Home />;
-      case 'chats':
-        return <Chats />;
-      case 'soldItems':
-        return <SoldItem />;
+  type tabPathType = '/' | '/sold-items' | '/chats';
+
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  //URLから状態を取得
+  const getActiveTab = () => {
+    switch (location.pathname) {
+      case'/chats':
+        return 'chats';
+      case'/sold-items':
+        return 'sold-items';
+      default:
+        return 'home';
     }
+  }
+
+    // タブ変更時の処理
+  const handleTabChange = (path: tabPathType) => {
+    navigate(path); // ページ遷移なしでURLのみを変更
   };
 
   return (
@@ -26,12 +31,12 @@ export default function Layout() {
       <Header />
       <main className="pt-32 pb-20">
         <div className="max-w-4xl mx-auto p-4">
-          {renderContent()}
+          <Outlet />
         </div>
       </main>
       <Footer 
-        activeTab={activeFooterTab} 
-        onTabChange={setActiveFooterTab} 
+        activeTab={getActiveTab()} 
+        onTabChange={handleTabChange} 
       />
     </div>
   );


### PR DESCRIPTION
・useStateでタブ切り替えの状態を管理していたものをuseLocationとuseNavigateをしようしたロジックへ変更
・変更に応じてルーティングも修正
・基本的に挙動は同じですがブラウザの戻るボタンを使用可能に